### PR TITLE
for local version label in pep440

### DIFF
--- a/src/simple_build/write/_wheel.py
+++ b/src/simple_build/write/_wheel.py
@@ -145,7 +145,11 @@ class WheelMetadata:
         """Post init."""
         pat = re.compile(r"[^\w\d.]+", re.UNICODE)
         name = pat.sub("-", self.name)
-        version = pat.sub("-", self.version)
+        if "+" in self.version:
+            pub_ver, local_ver = self.version
+            version = f"{pat.sub("-", pub_ver)}+{local_ver}"
+        else:
+            version = pat.sub("-", self.version)
         python = pat.sub("-", self.python)
         abi = pat.sub("-", self.abi)
         arch = pat.sub("-", self.arch)


### PR DESCRIPTION
As discussed, I hope the version of a filename support `local version label` https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-identifiers

This is a quick and dirty way. If we want it fully complied with pep440. The code in the following could be introduced

https://github.com/pypa/flit/blob/9896c52065fbb5978ed36f2f9b2e16a1dc0a1688/flit_core/flit_core/common.py#L13

