### PR TITLE
🐛 Fix wheel file normalization

### DIFF
--- a/src/simple_build/build.py
+++ b/src/simple_build/build.py
@@ -25,7 +25,7 @@ def build_wheel_metadata(root: Path, metadata_directory: Path) -> WheelFolderWri
     analysis = analyse_package(root)
     metadata = WheelMetadata(
         analysis.snake_name,
-        str(analysis.project["version"]),
+        analysis.project["version"],
         f"{__name__} {__version__}",
     )
     writer = WheelFolderWriter(metadata_directory, metadata)
@@ -52,7 +52,7 @@ def build_wheel(
     analysis = analyse_package(root)
     metadata = WheelMetadata(
         analysis.snake_name,
-        str(analysis.project["version"]),
+        analysis.project["version"],
         f"{__name__} {__version__}",
     )
     with WheelZipWriter(wheel_directory, metadata) as writer:


### PR DESCRIPTION
https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention supersedes https://peps.python.org/pep-0427/#file-name-convention, and as per that we should only normalise the name, not the version etc.