### PR TITLE
enable wheel config

### DIFF
--- a/src/simple_build/analyse/_pyproject.py
+++ b/src/simple_build/analyse/_pyproject.py
@@ -61,11 +61,24 @@ class SdistMetadata(t.TypedDict, total=False):
     """The list of files to exclude from the sdist."""
 
 
+class WheelMetadata(t.TypedDict, total=False):
+    """The sdist build configuration."""
+
+    use_git: bool
+    """Whether to use git to determine tracked files (default True)."""
+    include: list[str]
+    """The list of additional files to include in the sdist."""
+    exclude: list[str]
+    """The list of files to exclude from the sdist."""
+
+
 class ToolMetadata(t.TypedDict, total=False):
     """The parsed tool configuration."""
 
     sdist: "SdistMetadata"
     """The sdist build configuration."""
+    wheel: "WheelMetadata"
+    """The wheel build configuration."""
     pre_write_hooks: list["PreWriteHook"]
     """The list of pre-write hooks."""
 
@@ -130,6 +143,18 @@ def resolve_tool_section(  # type: ignore[misc]
             sresult = _resolve_tool_sdist_section(config["sdist"], root, tool_section)
             result.data["sdist"] = sresult[0]
             result.errors.extend(sresult[1])
+
+    if "wheel" in config:
+        if not isinstance(config["wheel"], dict):
+            result.errors.append(
+                ProjectValidationError(
+                    f"tool.{tool_section}.wheel", "type", "must be a table"
+                )
+            )
+        else:
+            wresult = _resolve_tool_sdist_section(config["wheel"], root, tool_section)
+            result.data["wheel"] = wresult[0]
+            result.errors.extend(wresult[1])
 
     return result
 

--- a/src/simple_build/write/_wheel.py
+++ b/src/simple_build/write/_wheel.py
@@ -56,8 +56,16 @@ def write_wheel(  # noqa: PLR0912
 
                 # TODO config options to include/exclude files in wheel modules,
                 # but they must allow for the behaviour above.
-
-                file_paths = gather_files(module, allow_non_git=True)
+                wheel_config = package.tool.get("wheel", {})
+                if not wheel_config:
+                    file_paths = gather_files(
+                        package.root,
+                        use_git=wheel_config.get("use_git", True),
+                        user_includes=wheel_config.get("include", []),
+                        user_excludes=wheel_config.get("exclude", []),
+                    )
+                else:
+                    file_paths = gather_files(module, allow_non_git=True)
             elif module.is_file():
                 file_paths = [module]
             else:
@@ -185,7 +193,7 @@ class WheelMetadata:
             f"""\
         Wheel-Version: 1.0
         Generator: {self.generator}
-        Root-Is-Purelib: {'true' if self.purelib else 'false'}
+        Root-Is-Purelib: {"true" if self.purelib else "false"}
         """
         )
         for tag in self.tags:

--- a/src/simple_build/write/_wheel.py
+++ b/src/simple_build/write/_wheel.py
@@ -57,9 +57,9 @@ def write_wheel(  # noqa: PLR0912
                 # TODO config options to include/exclude files in wheel modules,
                 # but they must allow for the behaviour above.
                 wheel_config = package.tool.get("wheel", {})
-                if not wheel_config:
+                if wheel_config != {}:
                     file_paths = gather_files(
-                        package.root,
+                        module,
                         use_git=wheel_config.get("use_git", True),
                         user_includes=wheel_config.get("include", []),
                         user_excludes=wheel_config.get("exclude", []),


### PR DESCRIPTION
When running rye build --wheel, simple-build respects `.gitinore` all the time. The config to enable the build only for wheel is proposed in this PR.  It is a quick fix for our `ubt-server` in ubtrace and does NOT thoroughly consider https://peps.python.org/pep-0517/#build-wheel so far. The improvement is super welcome
